### PR TITLE
Added check for `generateCompanionExtensions` to ensure correct component creation calls

### DIFF
--- a/compiler/src/main/kotlin/com/r0adkll/kimchi/util/ksp/SubcomponentDeclaration.kt
+++ b/compiler/src/main/kotlin/com/r0adkll/kimchi/util/ksp/SubcomponentDeclaration.kt
@@ -40,7 +40,9 @@ class SubcomponentDeclaration(
       )
   }
 
-  fun createFactoryFunctionOverload(): FunSpec = with(factoryClass) {
+  fun createFactoryFunctionOverload(
+    isGenerateCompanionExtensionsEnabled: Boolean,
+  ): FunSpec = with(factoryClass) {
     return FunSpec.buildFun(factoryFunction.simpleName.asString()) {
       addModifiers(KModifier.OVERRIDE)
 
@@ -51,8 +53,13 @@ class SubcomponentDeclaration(
 
       // Build the return statement constructing the expected merged subcomponent, including
       // parent.
+      val componentCreationFunction = if (isGenerateCompanionExtensionsEnabled) {
+        "%L.create"
+      } else {
+        "%L::class.create"
+      }
       addStatement(
-        "return %L.create(${factoryParameters.joinToString { "%L" }}" +
+        "return $componentCreationFunction(${factoryParameters.joinToString { "%L" }}" +
           "${if (factoryParameters.isNotEmpty()) ", " else ""}this)",
         subcomponentSimpleName,
         *factoryParameters.map { it.name }.toTypedArray(),

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -63,10 +63,6 @@ composeCompiler {
 
 android { namespace = "com.r0adkll.kimchi.restaurant" }
 
-//ksp {
-//  arg("me.tatarka.inject.generateCompanionExtensions", "true")
-//}
-
 private fun Project.addKspDependencyForAllTargets(dependencyNotation: Any) {
   val kmpExtension = extensions.getByType<KotlinMultiplatformExtension>()
   dependencies {

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -63,9 +63,9 @@ composeCompiler {
 
 android { namespace = "com.r0adkll.kimchi.restaurant" }
 
-ksp {
-  arg("me.tatarka.inject.generateCompanionExtensions", "true")
-}
+//ksp {
+//  arg("me.tatarka.inject.generateCompanionExtensions", "true")
+//}
 
 private fun Project.addKspDependencyForAllTargets(dependencyNotation: Any) {
   val kmpExtension = extensions.getByType<KotlinMultiplatformExtension>()


### PR DESCRIPTION
kotlin-inject has a ksp flag:

`me.tatarka.inject.generateCompanionExtensions`

That can optionally use component companion objects to instantiate themselves instead of call off the component `KClass` like so:

```kotlin
UserComponent.create(…)

vs 

UserComponent::class.create(…)
```

This PR checks that flag and changes how we call component creation under the hood in generated code