### PR TITLE
Added Circuit UI Function with Assisted Injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ TODO: Use https://github.com/ffurrer2/extract-release-notes when crafting a rele
 
 ### Other Notes & Contributions
 
+## [0.2.0] - 2024-08-26
+
+## Added
+
+- [Circuit] Added ability to inject additional elements into Ui composable functions - #30
 
 ## [0.1.1] - 2024-08-24
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,3 +145,8 @@ subprojects {
     }
   }
 }
+
+tasks.register<Copy>("bootstrap") {
+  from(file("scripts/pre-push"))
+  into(file(".git/hooks"))
+}

--- a/circuit/compiler/build.gradle.kts
+++ b/circuit/compiler/build.gradle.kts
@@ -6,10 +6,16 @@ plugins {
   alias(libs.plugins.ksp)
 }
 
+kotlin {
+  compilerOptions {
+    freeCompilerArgs.add("-Xopt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
+  }
+}
+
 dependencies {
   implementation(libs.autoservice.annotations)
-  implementation(libs.kotlininject.runtime)
   implementation(libs.kotlin.ksp)
+  implementation(libs.kotlininject.runtime)
   implementation(libs.kotlinpoet)
   implementation(libs.kotlinpoet.ksp)
 
@@ -18,4 +24,17 @@ dependencies {
   implementation(projects.compilerUtils)
 
   ksp(libs.ksp.autoservice)
+
+  testImplementation(testFixtures(projects.compilerUtils))
+  testImplementation(libs.bundles.junit5)
+  testImplementation(libs.circuit.runtime)
+  testImplementation(libs.junit5.engine)
+  testImplementation(libs.kotlin.compile.testing.ksp)
+  testImplementation(libs.strikt.core)
+}
+
+tasks {
+  test {
+    useJUnitPlatform()
+  }
 }

--- a/circuit/compiler/src/main/kotlin/com/r0adkll/kimchi/circuit/CircuitInjectSymbolProcessor.kt
+++ b/circuit/compiler/src/main/kotlin/com/r0adkll/kimchi/circuit/CircuitInjectSymbolProcessor.kt
@@ -21,7 +21,6 @@ import com.r0adkll.kimchi.util.KimchiException
 import com.r0adkll.kimchi.util.applyIf
 import com.r0adkll.kimchi.util.buildConstructor
 import com.r0adkll.kimchi.util.buildFile
-import com.r0adkll.kimchi.util.buildFun
 import com.r0adkll.kimchi.util.capitalized
 import com.r0adkll.kimchi.util.kotlinpoet.toParameterSpec
 import com.r0adkll.kimchi.util.ksp.directReturnTypeIs
@@ -169,10 +168,10 @@ class CircuitInjectSymbolProcessor(
                     PropertySpec.builder(param.name!!.asString(), param.type.toTypeName())
                       .initializer(param.name!!.asString())
                       .addModifiers(KModifier.PRIVATE)
-                      .build()
+                      .build(),
                   )
                 }
-              }
+              },
             )
           }
           .addFunction(

--- a/circuit/compiler/src/main/kotlin/com/r0adkll/kimchi/circuit/CircuitInjectSymbolProcessor.kt
+++ b/circuit/compiler/src/main/kotlin/com/r0adkll/kimchi/circuit/CircuitInjectSymbolProcessor.kt
@@ -18,8 +18,12 @@ import com.r0adkll.kimchi.circuit.util.ClassNames
 import com.r0adkll.kimchi.circuit.util.MemberNames
 import com.r0adkll.kimchi.circuit.util.addUiFactoryCreateStatement
 import com.r0adkll.kimchi.util.KimchiException
+import com.r0adkll.kimchi.util.applyIf
+import com.r0adkll.kimchi.util.buildConstructor
 import com.r0adkll.kimchi.util.buildFile
+import com.r0adkll.kimchi.util.buildFun
 import com.r0adkll.kimchi.util.capitalized
+import com.r0adkll.kimchi.util.kotlinpoet.toParameterSpec
 import com.r0adkll.kimchi.util.ksp.directReturnTypeIs
 import com.r0adkll.kimchi.util.ksp.getAllSymbolsWithAnnotation
 import com.r0adkll.kimchi.util.ksp.hasAnnotation
@@ -115,6 +119,19 @@ class CircuitInjectSymbolProcessor(
       throw KimchiException("Circuit Ui functions can only return 'Unit'", element)
     }
 
+    // These are the list of parameter types that can be resolved via a Ui.Factory, where
+    // any other parameters must be injected
+    val assistedParameterTypes = listOf(
+      annotation.screen,
+      ClassNames.Circuit.UiState,
+      ClassNames.Modifier,
+    )
+
+    // Filter out all the parameters that will need to be injected into the factory
+    val injectParameters = element.parameters.filter { param ->
+      assistedParameterTypes.none { param.implements(it) }
+    }
+
     return FileSpec.buildFile(packageName, classSimpleName) {
       addType(
         TypeSpec.interfaceBuilder(componentClassName)
@@ -141,6 +158,23 @@ class CircuitInjectSymbolProcessor(
           .addOriginatingKSFile(element.containingFile!!)
           .addAnnotation(Inject::class)
           .addSuperinterface(ClassNames.Circuit.UiFactory)
+          .applyIf(injectParameters.isNotEmpty()) {
+            primaryConstructor(
+              FunSpec.buildConstructor {
+                injectParameters.forEach { param ->
+                  addParameter(param.toParameterSpec())
+
+                  // Ensure that the params get set as properties and in the primary constructor
+                  addProperty(
+                    PropertySpec.builder(param.name!!.asString(), param.type.toTypeName())
+                      .initializer(param.name!!.asString())
+                      .addModifiers(KModifier.PRIVATE)
+                      .build()
+                  )
+                }
+              }
+            )
+          }
           .addFunction(
             FunSpec.builder("create")
               .addModifiers(KModifier.OVERRIDE)

--- a/circuit/compiler/src/main/kotlin/com/r0adkll/kimchi/circuit/util/UiFactory.kt
+++ b/circuit/compiler/src/main/kotlin/com/r0adkll/kimchi/circuit/util/UiFactory.kt
@@ -3,7 +3,6 @@
 package com.r0adkll.kimchi.circuit.util
 
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSValueParameter
 import com.r0adkll.kimchi.util.ksp.findActualType
 import com.r0adkll.kimchi.util.ksp.findParameterThatImplements
 import com.r0adkll.kimchi.util.ksp.findParameterThatIs
@@ -16,7 +15,6 @@ fun CodeBlock.Builder.addUiFactoryCreateStatement(
   element: KSFunctionDeclaration,
   screen: ClassName,
 ): CodeBlock.Builder = apply {
-
   // Build creation code block string, taking special account for the names
   // of parameters that we generate as part of the Ui.Factory, ignoring w/e the
   // user has named their parameters

--- a/circuit/compiler/src/main/kotlin/com/r0adkll/kimchi/circuit/util/UiFactory.kt
+++ b/circuit/compiler/src/main/kotlin/com/r0adkll/kimchi/circuit/util/UiFactory.kt
@@ -3,9 +3,11 @@
 package com.r0adkll.kimchi.circuit.util
 
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
 import com.r0adkll.kimchi.util.ksp.findActualType
 import com.r0adkll.kimchi.util.ksp.findParameterThatImplements
 import com.r0adkll.kimchi.util.ksp.findParameterThatIs
+import com.r0adkll.kimchi.util.ksp.implements
 import com.r0adkll.kimchi.util.toClassName
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -13,43 +15,38 @@ import com.squareup.kotlinpoet.CodeBlock
 fun CodeBlock.Builder.addUiFactoryCreateStatement(
   element: KSFunctionDeclaration,
   screen: ClassName,
-): CodeBlock.Builder {
+): CodeBlock.Builder = apply {
+
+  // Build creation code block string, taking special account for the names
+  // of parameters that we generate as part of the Ui.Factory, ignoring w/e the
+  // user has named their parameters
+  val callParameters = element.parameters.map { param ->
+    when {
+      param.implements(screen) -> "screen"
+      param.implements(ClassNames.Circuit.UiState) -> "state"
+      param.implements(ClassNames.Modifier) -> "modifier"
+      else -> param.name?.asString()
+    }
+  }
+
   // Since we need to account for stateless screens, i.e. [StaticScreen], we should search for parameters
   // that implement [StaticScreen] rather than assuming positions
   val stateClassParameter = element.findParameterThatImplements(ClassNames.Circuit.UiState)
-  val screenClassParameter = element.findParameterThatIs(screen)
 
   // Validate that a modifier exists, taking the assumption that it is the last parameter
   // due to the nature of standard composable function setups
   element.findParameterThatIs(ClassNames.Modifier)
     ?: throw IllegalStateException("@CircuitInject requires your composable function to have a Modifier parameter")
 
-  when {
-    stateClassParameter == null -> if (screenClassParameter != null) {
-      addStatement(
-        "%M<%T> { _, modifier -> %T(screen, modifier) }",
-        MemberNames.CircuitUi,
-        ClassNames.Circuit.UiState,
-        element.toClassName(),
-      )
-    } else {
-      addStatement(
-        "%M<%T> { _, modifier -> %T(modifier) }",
-        MemberNames.CircuitUi,
-        ClassNames.Circuit.UiState,
-        element.toClassName(),
-      )
-    }
-    else -> {
-      val stateClassName = stateClassParameter.type.findActualType().toClassName()
-      addStatement(
-        "%M<%T> { state, modifier -> %T(state, modifier) }",
-        MemberNames.CircuitUi,
-        stateClassName,
-        element.toClassName(),
-      )
-    }
-  }
-
-  return this
+  // If we couldn't find a provided state class name, assume that this is a [StaticScreen] and just pass a root
+  // [CircuitUiState] type parameter.
+  val stateClassName = stateClassParameter?.type?.findActualType()?.toClassName()
+    ?: ClassNames.Circuit.UiState
+  addStatement(
+    "%M<%T> { state, modifier -> %T(%L) }",
+    MemberNames.CircuitUi,
+    stateClassName,
+    element.toClassName(),
+    callParameters.joinToString(),
+  )
 }

--- a/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/TestSources.kt
+++ b/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/TestSources.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2024 r0adkll
+// SPDX-License-Identifier: Apache-2.0
 package com.r0adkll.kimchi.circuit
 
 import com.r0adkll.kimchi.compileKimchi

--- a/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/TestSources.kt
+++ b/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/TestSources.kt
@@ -1,0 +1,118 @@
+package com.r0adkll.kimchi.circuit
+
+import com.r0adkll.kimchi.compileKimchi
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import java.io.File
+import org.intellij.lang.annotations.Language
+
+@Language("kotlin")
+val TestScreen = """
+  package kimchi
+  import com.slack.circuit.runtime.screen.Screen
+  data object TestScreen : Screen
+""".trimIndent()
+
+@Language("kotlin")
+val TestUiState = """
+  package kimchi
+  import com.slack.circuit.runtime.CircuitUiState
+  class TestUiState : CircuitUiState
+""".trimIndent()
+
+@Language("kotlin")
+val TestScope = """
+  package kimchi
+  object TestScope
+""".trimIndent()
+
+@Language("kotlin")
+val Composable = """
+  package androidx.compose.runtime
+  @Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPE,
+    AnnotationTarget.TYPE_PARAMETER,
+    AnnotationTarget.PROPERTY_GETTER
+  )
+  annotation class Composable
+""".trimIndent()
+
+@Language("kotlin")
+val Modifier = """
+  package androidx.compose.ui
+  interface Modifier {
+    companion object : Modifier
+  }
+""".trimIndent()
+
+@Language("kotlin")
+val CircuitUiState = """
+  package com.slack.circuit.runtime
+  interface CircuitUiState
+""".trimIndent()
+
+@Language("kotlin")
+val CircuitContext = """
+  package com.slack.circuit.runtime
+  class CircuitContext
+""".trimIndent()
+
+@Language("kotlin")
+val CircuitScreen = """
+  package com.slack.circuit.runtime.screen
+  interface Screen
+""".trimIndent()
+
+@Language("kotlin")
+val CircuitUi = """
+  package com.slack.circuit.runtime.ui
+
+  import androidx.compose.runtime.Composable
+  import androidx.compose.runtime.Stable
+  import androidx.compose.ui.Modifier
+  import com.slack.circuit.runtime.CircuitContext
+  import com.slack.circuit.runtime.CircuitUiState
+  import com.slack.circuit.runtime.screen.Screen
+
+  @Stable
+  interface Ui<UiState : CircuitUiState> {
+    @Composable fun Content(state: UiState, modifier: Modifier)
+
+    fun interface Factory {
+      fun create(screen: Screen, context: CircuitContext): Ui<*>?
+    }
+  }
+
+  inline fun <UiState : CircuitUiState> ui(
+    crossinline body: @Composable (state: UiState, modifier: Modifier) -> Unit
+  ): Ui<UiState> {
+    return object : Ui<UiState> {
+      @Composable
+      override fun Content(state: UiState, modifier: Modifier) {
+        body(state, modifier)
+      }
+    }
+  }
+""".trimIndent()
+
+fun compileKimchiWithTestSources(
+  @Language("kotlin") vararg sources: String,
+  expectExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
+  workingDir: File? = null,
+  block: JvmCompilationResult.() -> Unit,
+) = compileKimchi(
+  *sources,
+  TestScreen,
+  TestUiState,
+  TestScope,
+  CircuitUiState,
+  CircuitContext,
+  CircuitScreen,
+  CircuitUi,
+  Composable,
+  Modifier,
+  expectExitCode = expectExitCode,
+  workingDir = workingDir,
+  block = block,
+)

--- a/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/UiFunctionFactoryTest.kt
+++ b/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/UiFunctionFactoryTest.kt
@@ -1,0 +1,53 @@
+package com.r0adkll.kimchi.circuit
+
+import java.io.File
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.CleanupMode
+import org.junit.jupiter.api.io.TempDir
+import strikt.api.expectThat
+import strikt.assertions.elementAt
+import strikt.assertions.hasSize
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.withElementAt
+
+class UiFunctionFactoryTest {
+
+  @TempDir
+  lateinit var workingDir: File
+
+  @Test
+  fun `ui composable function with injected parameters injects into factory`() {
+    println(workingDir.absolutePath)
+    compileKimchiWithTestSources(
+      """
+        package kimchi
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import com.r0adkll.kimchi.circuit.annotations.CircuitInject
+
+        class Injected
+
+        @CircuitInject(TestScreen::class, TestScope::class)
+        @Composable
+        fun TestUi(
+          state: TestUiState,
+          injected: Injected,
+          modifier: Modifier = Modifier,
+        ) { }
+      """.trimIndent(),
+      workingDir = workingDir,
+    ) {
+      val factory = classLoader.loadClass("kimchi.TestUiUiFactory")
+      val injectedComposable = classLoader.loadClass("kimchi.Injected")
+      val primaryConstructor = factory.constructors.first()
+
+      expectThat(primaryConstructor.parameters.toList())
+        .hasSize(1)
+        .withElementAt(0) {
+          get { type } isEqualTo injectedComposable
+        }
+    }
+  }
+}

--- a/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/UiFunctionFactoryTest.kt
+++ b/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/UiFunctionFactoryTest.kt
@@ -1,14 +1,13 @@
+// Copyright (C) 2024 r0adkll
+// SPDX-License-Identifier: Apache-2.0
 package com.r0adkll.kimchi.circuit
 
 import java.io.File
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.CleanupMode
 import org.junit.jupiter.api.io.TempDir
 import strikt.api.expectThat
-import strikt.assertions.elementAt
 import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
-import strikt.assertions.isNotNull
 import strikt.assertions.withElementAt
 
 class UiFunctionFactoryTest {

--- a/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/KotlinPoetUtils.kt
+++ b/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/KotlinPoetUtils.kt
@@ -39,4 +39,14 @@ public fun FunSpec.Companion.buildFun(
   .apply(builder)
   .build()
 
+public fun FunSpec.Companion.buildConstructor(
+  builder: FunSpec.Builder.() -> Unit,
+): FunSpec = constructorBuilder()
+  .apply(builder)
+  .build()
+
 public fun KSDeclaration.toClassName(): ClassName = ClassName(packageName.asString(), simpleName.asString())
+
+public fun <T> T.applyIf(predicate: Boolean, block: T.() -> Unit): T {
+  return if (predicate) apply(block) else this
+}

--- a/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/ksp/FunctionDeclarations.kt
+++ b/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/ksp/FunctionDeclarations.kt
@@ -17,14 +17,23 @@ import kotlin.reflect.KClass
  * passed [className]
  */
 public fun KSFunctionDeclaration.findParameterThatImplements(className: ClassName): KSValueParameter? {
-  return parameters.find { parameter ->
-    val classDecl = parameter.type.resolve().declaration as? KSClassDeclaration
-    if (classDecl != null) {
-      return@find classDecl.getAllSuperTypes()
-        .any { it.declaration.toClassName() == className }
-    }
-    false
+  return parameters.find { parameter -> parameter.implements(className) }
+}
+
+/**
+ * Return whether or not the current [KSValueParameter] implements the passed [className]
+ * @receiver a [KSValueParameter] to evaluate
+ * @param className the [ClassName] of the type you are looking for
+ */
+public fun KSValueParameter.implements(className: ClassName): Boolean {
+  val classDecl = type.resolve().declaration as? KSClassDeclaration
+  if (classDecl != null) {
+    // Check if the direct type implements the passed className
+    if (classDecl.toClassName() == className) return true
+    return classDecl.getAllSuperTypes()
+      .any { it.declaration.toClassName() == className }
   }
+  return false
 }
 
 public fun KSFunctionDeclaration.findParameterThatIs(className: ClassName): KSValueParameter? {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 # Ignore disabled targets (i.e iOS on Linux)
 kotlin.native.ignoreDisabledTargets=true
+kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 
 # New Kotlin IC flags
 kotlin.compiler.suppressExperimentalICOptimizationsWarning=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ strikt-core = { module = "io.strikt:strikt-core", version.ref = "strikt" }
 circuit-foundation = { module = "com.slack.circuit:circuit-foundation", version.ref = "circuit" }
 circuit-overlay = { module = "com.slack.circuit:circuit-overlay", version.ref = "circuit" }
 circuit-runtime = { module = "com.slack.circuit:circuit-runtime", version.ref = "circuit" }
+circuit-runtime-ui = { module = "com.slack.circuit:circuit-runtime-ui", version.ref = "circuit" }
 circuitx-gesturenav = { module = "com.slack.circuit:circuitx-gesture-navigation", version.ref = "circuit" }
 uuid = "com.benasher44:uuid:0.8.4"
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "**** Running Pre-Push Check ****"
+
+git stash -q --keep-index
+
+./gradlew spotlessCheck
+./gradlew -P gradle/build-logic spotlessCheck
+
+status=$?
+
+git stash pop -q
+
+echo "**** Pre-Push Check Finished ****"
+
+exit $status

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -5,7 +5,6 @@ echo "**** Running Pre-Push Check ****"
 git stash -q --keep-index
 
 ./gradlew spotlessCheck
-./gradlew -P gradle/build-logic spotlessCheck
 
 status=$?
 

--- a/scripts/spotlessApply
+++ b/scripts/spotlessApply
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./gradlew spotlessApply
+./gradlew -P gradle/build-logic spotlessApply

--- a/scripts/spotlessApply
+++ b/scripts/spotlessApply
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 ./gradlew spotlessApply
-./gradlew -P gradle/build-logic spotlessApply

--- a/scripts/test_danger
+++ b/scripts/test_danger
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+kotlinc -J-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:8001 -script-templates systems.danger.kts.DangerFileScript \
+-cp /usr/local/lib/danger/danger-kotlin.jar \
+-script Dangerfile.df.kts \
+-Dkotlin.script.classpath=/usr/local/lib/danger/danger-kotlin.jar


### PR DESCRIPTION
You can now add additional parameters to circuit composable ui function annotated with `@CircuitInject` that can be injected via its generate Factory.

Take this example:

```kotlin
@CircuitInject(HomeScreen::class, UserScope::class)
@Composable
fun HomeUi(
  state: HomeUiState, 
  appBarContent: AppBarContent, 
  modifier: Modifier = Modifier
) { /*...*/ }
```

Will now generate a factory that injects `AppBarContent` and passes it to the creation call of this Ui composable when Circuit creates the screen.