### PR TITLE
Added check for `@Inject` annotations on `@ContributesBinding` elements with constructor injections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other Notes & Contributions
 -->
 
+### Fixed
+
+- Fixed issue where @ContributesBinding elements with constructor injections and no @Inject annotation
+
 ## [0.2.0] - 2024-08-24
 
 ### Added

--- a/compiler/src/main/kotlin/com/r0adkll/kimchi/processors/ContributesBindingSymbolProcessor.kt
+++ b/compiler/src/main/kotlin/com/r0adkll/kimchi/processors/ContributesBindingSymbolProcessor.kt
@@ -10,8 +10,11 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.r0adkll.kimchi.HINT_BINDING_PACKAGE
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import com.r0adkll.kimchi.annotations.ContributesBindingAnnotation
+import com.r0adkll.kimchi.util.KimchiException
+import com.r0adkll.kimchi.util.ksp.hasAnnotation
 import com.squareup.kotlinpoet.ClassName
 import kotlin.reflect.KClass
+import me.tatarka.inject.annotations.Inject
 
 internal class ContributesBindingSymbolProcessor(
   env: SymbolProcessorEnvironment,
@@ -29,5 +32,19 @@ internal class ContributesBindingSymbolProcessor(
 
   override fun getScope(element: KSClassDeclaration): ClassName {
     return ContributesBindingAnnotation.from(element).scope
+  }
+
+  override fun validate(element: KSClassDeclaration) {
+    val hasInjectAnnotation = element.hasAnnotation(Inject::class)
+    val hasInjectedParameters = element.primaryConstructor
+      ?.parameters
+      ?.isNotEmpty() == true
+
+    if (hasInjectedParameters && !hasInjectAnnotation) {
+      throw KimchiException(
+        "@ContributesBinding annotated classes with injected constructor parameters require an '@Inject' annotation",
+        element,
+      )
+    }
   }
 }

--- a/compiler/src/test/kotlin/com/r0adkll/kimchi/processors/ContributedBindingTest.kt
+++ b/compiler/src/test/kotlin/com/r0adkll/kimchi/processors/ContributedBindingTest.kt
@@ -63,6 +63,25 @@ class ContributedBindingTest {
   }
 
   @Test
+  fun `contributed binding without @Inject fails`() {
+    compileKimchiWithTestSources(
+      """
+        package kimchi
+
+        import me.tatarka.inject.annotations.Inject
+        import com.r0adkll.kimchi.annotations.ContributesBinding
+
+        interface Binding
+
+        @ContributesBinding(TestScope::class)
+        class RealBinding(val param: Any) : Binding
+      """.trimIndent(),
+      workingDir = workingDir,
+      expectExitCode = KotlinCompilation.ExitCode.INTERNAL_ERROR,
+    )
+  }
+
+  @Test
   fun `contributed binding object class gets added to a component`() {
     compileKimchiWithTestSources(
       """


### PR DESCRIPTION
When generating bindings where the implementation has constructor injected parameters we require that element to be annotated with `@Inject` or otherwise it attempts to create a provision like its an object