### PR TITLE
Fixed how explicit parent components are passed to @MergeComponent

### DIFF
--- a/.run/Desktop App.run.xml
+++ b/.run/Desktop App.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Desktop App" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="azul-17" />
+    <option name="ALTERNATIVE_JRE_PATH" value="zulu-17" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.r0adkll.kimchi.restaurant.MainKt" />
     <module name="kimchi.sample.desktopApp.main" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,29 +21,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other Notes & Contributions
 -->
 
+### Fixed
+
+- Fixed explicit parent components with @MergeComponent components - [#52](https://github.com/r0adkll/kimchi/pull/52)
+
 ## [0.3.1] - 2024-09-10
 
 ### Fixed
 
-- Fixed naive `toClassName()` function that broke on nested classes - [https://github.com/r0adkll/kimchi/pull/48]
+- Fixed naive `toClassName()` function that broke on nested classes - [#48](https://github.com/r0adkll/kimchi/pull/48)
 
 ## [0.3.0] - 2024-09-09
 
 ### Fixed
 
 - Fixed issue where @ContributesBinding elements with constructor injections and no @Inject annotation
-- Fixed annotations passed to merged implementations clashing with kotlin-inject generation. - [https://github.com/r0adkll/kimchi/pull/43]
-- Fixed root component creation extension function to account for defined companion objects. - [https://github.com/r0adkll/kimchi/pull/39]
+- Fixed annotations passed to merged implementations clashing with kotlin-inject generation. - [#43](https://github.com/r0adkll/kimchi/pull/43)
+- Fixed root component creation extension function to account for defined companion objects. - [#39](https://github.com/r0adkll/kimchi/pull/39)
 
 ## [0.2.0] - 2024-08-24
 
 ### Added
 
-- [Circuit] Added ability to inject additional elements into Ui composable functions - [https://github.com/r0adkll/kimchi/pull/30]
+- [Circuit] Added ability to inject additional elements into Ui composable functions - [#30](https://github.com/r0adkll/kimchi/pull/30)
 
 ### Fixed
 
-- Fixed `rank` ordering when contributing multiple bindings of the same type - [https://github.com/r0adkll/kimchi/pull/34]
+- Fixed `rank` ordering when contributing multiple bindings of the same type - [#34](https://github.com/r0adkll/kimchi/pull/34)
 
 ## [0.1.1] - 2024-08-24
 

--- a/compiler/src/main/kotlin/com/r0adkll/kimchi/processors/ContributesSubcomponentSymbolProcessor.kt
+++ b/compiler/src/main/kotlin/com/r0adkll/kimchi/processors/ContributesSubcomponentSymbolProcessor.kt
@@ -11,7 +11,7 @@ import com.r0adkll.kimchi.HINT_SUBCOMPONENT_PACKAGE
 import com.r0adkll.kimchi.annotations.ContributesSubcomponent
 import com.r0adkll.kimchi.annotations.ContributesSubcomponentAnnotation
 import com.r0adkll.kimchi.util.KimchiException
-import com.r0adkll.kimchi.util.ksp.SubcomponentDeclaration
+import com.r0adkll.kimchi.util.ksp.component.SubcomponentDeclaration
 import com.r0adkll.kimchi.util.ksp.hasAnnotation
 import com.r0adkll.kimchi.util.ksp.isInterface
 import com.squareup.kotlinpoet.ClassName

--- a/compiler/src/main/kotlin/com/r0adkll/kimchi/util/ksp/ConstructorParameter.kt
+++ b/compiler/src/main/kotlin/com/r0adkll/kimchi/util/ksp/ConstructorParameter.kt
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 r0adkll
+// SPDX-License-Identifier: Apache-2.0
+package com.r0adkll.kimchi.util.ksp
+
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+
+/**
+ * Represents a parameter to be added to a generated Merged component,
+ * including the value property spec if it is not just passed through
+ * to the superclass implementation.
+ */
+class ConstructorParameter(
+  val parameterSpec: ParameterSpec,
+  val propertySpec: PropertySpec? = null,
+)
+
+/**
+ * Convenience helper function for adding all the [ConstructorParameter.parameterSpec]
+ * to a given function builder.
+ */
+fun FunSpec.Builder.addParameters(parameters: List<ConstructorParameter>): FunSpec.Builder {
+  return addParameters(parameters.map { it.parameterSpec })
+}

--- a/compiler/src/main/kotlin/com/r0adkll/kimchi/util/ksp/component/ComponentDeclaration.kt
+++ b/compiler/src/main/kotlin/com/r0adkll/kimchi/util/ksp/component/ComponentDeclaration.kt
@@ -1,0 +1,15 @@
+// Copyright (C) 2024 r0adkll
+// SPDX-License-Identifier: Apache-2.0
+package com.r0adkll.kimchi.util.ksp.component
+
+import com.r0adkll.kimchi.util.ksp.ConstructorParameter
+
+/**
+ * A central interface for [com.r0adkll.kimchi.annotations.MergeComponent]
+ * and [com.r0adkll.kimchi.annotations.ContributesSubcomponent] for generating
+ * the parameter list needed to build the constructor of the generated Merged component
+ */
+interface ComponentDeclaration {
+
+  fun constructorParameters(): List<ConstructorParameter>
+}

--- a/compiler/src/main/kotlin/com/r0adkll/kimchi/util/ksp/component/MergeComponentDeclaration.kt
+++ b/compiler/src/main/kotlin/com/r0adkll/kimchi/util/ksp/component/MergeComponentDeclaration.kt
@@ -1,0 +1,85 @@
+// Copyright (C) 2024 r0adkll
+// SPDX-License-Identifier: Apache-2.0
+package com.r0adkll.kimchi.util.ksp.component
+
+import com.google.devtools.ksp.getDeclaredProperties
+import com.google.devtools.ksp.isOpen
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.r0adkll.kimchi.annotations.MergeComponentAnnotation
+import com.r0adkll.kimchi.util.KimchiException
+import com.r0adkll.kimchi.util.applyIf
+import com.r0adkll.kimchi.util.ksp.ConstructorParameter
+import com.r0adkll.kimchi.util.ksp.hasAnnotation
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.ksp.toTypeName
+import me.tatarka.inject.annotations.Component
+
+class MergeComponentDeclaration(
+  private val clazz: KSClassDeclaration,
+) : KSClassDeclaration by clazz, ComponentDeclaration {
+
+  val annotation: MergeComponentAnnotation by lazy {
+    MergeComponentAnnotation.from(clazz)
+  }
+
+  override fun constructorParameters(): List<ConstructorParameter> {
+    return primaryConstructor?.let { primaryConstructor ->
+      primaryConstructor.parameters.map { param ->
+        val name = param.name!!.asString()
+        val type = param.type.toTypeName()
+
+        if (param.hasAnnotation(Component::class)) {
+          // Due to the nature of kotlin inheritance passed parent components must be either
+          // open value parameters, or no value params
+          if (param.isVal) {
+            val isOpen = getDeclaredProperties()
+              .find { it.simpleName.asString() == name }
+              ?.isOpen() == true
+
+            if (!isOpen) {
+              throw KimchiException(
+                "Parent @Component properties passed to @MergeComponent classes must be " +
+                  "marked `open` or have no val modifiers",
+                node = this,
+              )
+            }
+          } else if (param.isVar || param.isVararg) {
+            throw KimchiException(
+              "Parent @Component properties passed to @MergeComponent classes must be " +
+                "marked `open val` or have no val modifiers",
+              node = this,
+            )
+          }
+
+          // If the constructor parameter is annotated with @Component,
+          // then we'll want to make sure the merged component parameter
+          // is also annotated with @Component and is a value property
+          ConstructorParameter(
+            parameterSpec = ParameterSpec.builder(name, type)
+              .addAnnotation(Component::class)
+              .build(),
+            propertySpec = PropertySpec.builder(name, type)
+              .initializer(name)
+              // If the parameter is a val, we need to assume that it is an
+              // `open val` and add an override modifier here
+              .applyIf(param.isVal) {
+                addModifiers(KModifier.OVERRIDE)
+              }
+              .build(),
+          )
+        } else {
+          // If the constructor parameter is NOT annotated with @Component,
+          // then do not cary over any annotations.
+          // kotlin-inject seems to respect @get:Provides annotations in the
+          // super class so we don't need to duplicate them here
+          ConstructorParameter(
+            ParameterSpec.builder(name, type)
+              .build(),
+          )
+        }
+      }
+    } ?: emptyList()
+  }
+}


### PR DESCRIPTION
Looks like I misunderstood how kotlin-inject handles parent components and thought that it would handle them via inheritance. 

This adds proper support for passing them either as non-value parameters, e.g.

```kotlin
@MergeComponent(…)
abstract class SomeComponent(
  @Component parent: ParentComponent
)
```

or as open value parameters, e.g.

```kotlin
@MergeComponent(…)
abstract class SomeComponent(
  @Component open val parent: ParentComponent
)
```

Added some additional tests around these use cases to ensure correctness

Fixes #51 