### PR TITLE
Use FQ names for generated hint files to avoid collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed explicit parent components with @MergeComponent components - [#52](https://github.com/r0adkll/kimchi/pull/52)
 - Fixed non-primitive custom keys not generating correctly - [#55](https://github.com/r0adkll/kimchi/pull/55)
+- Fixed name collisions with generated hint classes - [#56](https://github.com/r0adkll/kimchi/pull/56)
 
 ## [0.3.1] - 2024-09-10
 

--- a/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/ksp/ClassDeclarations.kt
+++ b/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/ksp/ClassDeclarations.kt
@@ -4,6 +4,7 @@ package com.r0adkll.kimchi.util.ksp
 
 import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSName
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ksp.toClassName
 
@@ -16,3 +17,6 @@ public fun KSClassDeclaration.implements(className: ClassName): Boolean {
     it.toClassName() == className
   }
 }
+
+public val KSClassDeclaration.requireQualifiedName: KSName
+  get() = qualifiedName!!

--- a/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/ksp/KSName.kt
+++ b/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/ksp/KSName.kt
@@ -1,0 +1,12 @@
+// Copyright (C) 2024 r0adkll
+// SPDX-License-Identifier: Apache-2.0
+package com.r0adkll.kimchi.util.ksp
+
+import com.google.devtools.ksp.symbol.KSName
+
+/**
+ * Convert a [KSName] to a URL-safe string that can be used as a file name
+ * @receiver [KSName]
+ * @return a url safe name with '.' replaced with '_' characters
+ */
+public fun KSName.asUrlSafeString(): String = asString().replace(".", "_")

--- a/compiler/src/main/kotlin/com/r0adkll/kimchi/processors/HintSymbolProcessor.kt
+++ b/compiler/src/main/kotlin/com/r0adkll/kimchi/processors/HintSymbolProcessor.kt
@@ -10,6 +10,8 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.r0adkll.kimchi.REFERENCE_SUFFIX
 import com.r0adkll.kimchi.SCOPE_SUFFIX
 import com.r0adkll.kimchi.util.buildFile
+import com.r0adkll.kimchi.util.ksp.asUrlSafeString
+import com.r0adkll.kimchi.util.ksp.requireQualifiedName
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
@@ -65,10 +67,10 @@ internal abstract class HintSymbolProcessor(
   private fun process(
     element: KSClassDeclaration,
   ): FileSpec {
-    val fileName = element.simpleName.asString()
+    // TODO: In other examples using the fq name for file names has been known to hit length limits
+    //  so we should look into using a hash instead.
+    val fileName = element.requireQualifiedName.asUrlSafeString()
     val className = element.toClassName()
-    val propertyName = element.qualifiedName!!.asString()
-      .replace(".", "_")
 
     validate(element)
 
@@ -79,7 +81,7 @@ internal abstract class HintSymbolProcessor(
       addProperty(
         PropertySpec
           .builder(
-            name = propertyName + REFERENCE_SUFFIX,
+            name = fileName + REFERENCE_SUFFIX,
             type = KClass::class.asClassName().parameterizedBy(className),
           )
           .initializer("%T::class", className)
@@ -91,7 +93,7 @@ internal abstract class HintSymbolProcessor(
       addProperty(
         PropertySpec
           .builder(
-            name = propertyName + SCOPE_SUFFIX,
+            name = fileName + SCOPE_SUFFIX,
             type = KClass::class.asClassName().parameterizedBy(scope),
           )
           .initializer("%T::class", scope)

--- a/compiler/src/test/kotlin/com/r0adkll/kimchi/processors/HintSymbolProcessorTest.kt
+++ b/compiler/src/test/kotlin/com/r0adkll/kimchi/processors/HintSymbolProcessorTest.kt
@@ -16,6 +16,8 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import java.io.File
 import kotlin.reflect.KClass
 import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.CleanupMode
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -24,7 +26,7 @@ import strikt.assertions.isEqualTo
 
 class HintSymbolProcessorTest {
 
-  @TempDir
+  @TempDir(cleanup = CleanupMode.NEVER)
   lateinit var workingDir: File
 
   @ParameterizedTest
@@ -42,6 +44,30 @@ class HintSymbolProcessorTest {
       expectThat(hint).isEqualTo(hintTest.expectedHint(this))
       expectThat(scope).isEqualTo(hintTest.expectedScope(this))
     }
+  }
+
+  @Test
+  fun `Duplicate class names do NOT cause a collision`() {
+    println(workingDir.absolutePath)
+    compileKimchiWithTestSources(
+      """
+        package kimchi
+
+        import com.r0adkll.kimchi.annotations.ContributesTo
+
+        interface Outer1 {
+          @ContributesTo(TestScope::class)
+          interface Inner
+        }
+
+        interface Outer2 {
+          @ContributesTo(TestScope::class)
+          interface Inner
+        }
+      """.trimIndent(),
+      workingDir = workingDir,
+      expectExitCode = KotlinCompilation.ExitCode.OK,
+    )
   }
 
   companion object {

--- a/compiler/src/test/kotlin/com/r0adkll/kimchi/processors/HintSymbolProcessorTest.kt
+++ b/compiler/src/test/kotlin/com/r0adkll/kimchi/processors/HintSymbolProcessorTest.kt
@@ -26,7 +26,7 @@ import strikt.assertions.isEqualTo
 
 class HintSymbolProcessorTest {
 
-  @TempDir(cleanup = CleanupMode.NEVER)
+  @TempDir(cleanup = CleanupMode.ON_SUCCESS)
   lateinit var workingDir: File
 
   @ParameterizedTest


### PR DESCRIPTION
Switched to using FQ names of annotated classes for the generated hint file name to avoid collisions.

Fixes #53 