### PR TITLE
Fixed Circuit presenter class generation with @CircuitInject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other Notes & Contributions
 -->
 
+### Fixed
+
+- Fixed Circuit presenter code generator - [#98](https://github.com/r0adkll/kimchi/pull/98)
+
 ## [0.5.0] - 2024-12-19
 
 ### Added

--- a/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/PresenterClassFactoryTest.kt
+++ b/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/PresenterClassFactoryTest.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2025 r0adkll
+// SPDX-License-Identifier: Apache-2.0
 package com.r0adkll.kimchi.circuit
 
 import com.r0adkll.kimchi.annotations.ContributesTo
@@ -68,7 +70,7 @@ class PresenterClassFactoryTest {
         .isNotNull()
         .parameter(0)
         .isTypeOf(Function3::class)
-        .with({type.arguments}) {
+        .with({ type.arguments }) {
           withElementAt(0) {
             get { type!!.classifier } isEqualTo testScreen
           }

--- a/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/PresenterClassFactoryTest.kt
+++ b/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/PresenterClassFactoryTest.kt
@@ -1,0 +1,100 @@
+package com.r0adkll.kimchi.circuit
+
+import com.r0adkll.kimchi.annotations.ContributesTo
+import com.r0adkll.kimchi.hasAnnotation
+import com.r0adkll.kimchi.hasReturnType
+import com.r0adkll.kimchi.implements
+import com.r0adkll.kimchi.isTypeOf
+import com.r0adkll.kimchi.kotlinClass
+import com.r0adkll.kimchi.parameter
+import com.r0adkll.kimchi.primaryConstructor
+import com.r0adkll.kimchi.withAnnotation
+import com.r0adkll.kimchi.withFunction
+import com.slack.circuit.runtime.CircuitContext
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import java.io.File
+import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.IntoSet
+import me.tatarka.inject.annotations.Provides
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.CleanupMode
+import org.junit.jupiter.api.io.TempDir
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.withElementAt
+
+class PresenterClassFactoryTest {
+
+  @TempDir(cleanup = CleanupMode.ON_SUCCESS)
+  lateinit var workingDir: File
+
+  @Test
+  fun `Presenter class generates factory and contributed component`() {
+    compileKimchiWithTestSources(
+      """
+        package kimchi
+
+        import androidx.compose.runtime.Composable
+        import me.tatarka.inject.annotations.Assisted
+        import me.tatarka.inject.annotations.Inject
+        import com.r0adkll.kimchi.circuit.annotations.CircuitInject
+        import com.slack.circuit.runtime.Navigator
+        import com.slack.circuit.runtime.presenter.Presenter
+        import com.slack.circuit.runtime.CircuitContext
+
+        @CircuitInject(TestScreen::class, TestScope::class)
+        @Inject
+        class TestPresenter(
+          @Assisted private val screen: TestScreen,
+          @Assisted private val navigator: Navigator,
+          @Assisted private val context: CircuitContext,
+        ) : Presenter<TestUiState> {
+
+            @Composable
+            override fun present(): TestUiState {
+              return TestUiState()
+            }
+        }
+      """.trimIndent(),
+      workingDir = workingDir,
+    ) {
+      val factory = kotlinClass("kimchi.TestPresenterFactory")
+      expectThat(factory)
+        .hasAnnotation(Inject::class)
+        .implements(Presenter.Factory::class)
+        .primaryConstructor()
+        .isNotNull()
+        .parameter(0)
+        .isTypeOf(Function3::class)
+        .with({type.arguments}) {
+          withElementAt(0) {
+            get { type!!.classifier } isEqualTo testScreen
+          }
+          withElementAt(1) {
+            get { type!!.classifier } isEqualTo Navigator::class
+          }
+          withElementAt(2) {
+            get { type!!.classifier } isEqualTo CircuitContext::class
+          }
+          withElementAt(3) {
+            get { type!!.classifier } isEqualTo kotlinClass("kimchi.TestPresenter")
+          }
+        }
+
+      val component = kotlinClass("kimchi.TestPresenterFactoryComponent")
+      expectThat(component)
+        .withAnnotation<ContributesTo> {
+          get { scope } isEqualTo testScope
+        }
+        .withFunction("bindTestPresenterFactory") {
+          hasAnnotation(IntoSet::class)
+          hasAnnotation(Provides::class)
+          parameter(1)
+            .isTypeOf(factory)
+          hasReturnType(Presenter.Factory::class)
+        }
+    }
+  }
+}

--- a/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/UiFunctionFactoryTest.kt
+++ b/circuit/compiler/src/test/kotlin/com/r0adkll/kimchi/circuit/UiFunctionFactoryTest.kt
@@ -26,7 +26,7 @@ import strikt.assertions.isNotNull
 
 class UiFunctionFactoryTest {
 
-  @TempDir(cleanup = CleanupMode.NEVER)
+  @TempDir(cleanup = CleanupMode.ON_SUCCESS)
   lateinit var workingDir: File
 
   @Test

--- a/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/ksp/ClassDeclarations.kt
+++ b/compiler-utils/src/main/kotlin/com/r0adkll/kimchi/util/ksp/ClassDeclarations.kt
@@ -6,6 +6,7 @@ import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSName
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ksp.toTypeName
 
 /**
@@ -14,7 +15,10 @@ import com.squareup.kotlinpoet.ksp.toTypeName
  */
 public fun KSClassDeclaration.implements(className: ClassName): Boolean {
   return getAllSuperTypes().any {
-    it.toTypeName() == className
+    when (val typeName = it.toTypeName()) {
+      is ParameterizedTypeName -> typeName.rawType == className
+      else -> typeName == className
+    }
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,9 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
 
+#Dokka v2
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
+
 #Kotlin
 kotlin.code.style=official
 


### PR DESCRIPTION
There was a bug from the kotlinpoet update that caused our `.implements(…)` check to fail due to the invalid comparison of TypeName <> ClassName that we were trying to do. 